### PR TITLE
Componenete ErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary/index.jsx
+++ b/src/components/ErrorBoundary/index.jsx
@@ -1,0 +1,23 @@
+import { Component } from "react";
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
El componente ErrorBoundary es utilizado para lanzar un error durante el renderizado, por ejemplo en la llamada a una API.